### PR TITLE
Pass device to pipeline and fix regexp warnings

### DIFF
--- a/runorm/runorm.py
+++ b/runorm/runorm.py
@@ -21,7 +21,7 @@ class RUNorm:
         self.rule_normalizer = RuleNormalizer()
         self.numbers_normalizer = Numbers2Words()
         self.re_tokens = re.compile(r"(?:[.,!?]|[а-яА-Я]\S*|-?\d\S*(?:\.\d+)?|[^а-яА-Я\d\s-]+)\s*")
-        self.re_normalization = re.compile(r"[^a-zA-Z0-9\sа-яА-ЯёЁ.,!?:;""''(){}\[\]«»„“”-]")
+        self.re_normalization = re.compile(r"[^a-zA-Z0-9\sа-яА-ЯёЁ.,!?:;""''(){}[]«»„“”-]")
         self.paths = {
             "tagger": "RUNorm/RUNorm-tagger",
             "kirillizator": "RUNorm/RUNorm-kirillizator",
@@ -107,7 +107,7 @@ class RUNorm:
         etid = 0
         token_to_add = ""
         for token in self.process_sentence(text) + [""]:
-            if not re.search("[a-zA-Z\d]", token):
+            if not re.search(r"[a-zA-Z\d]", token):
                 if token_to_add:
                     end_match = re.search(r"(.+?)(\W*)$", token_to_add, re.M).groups()
                     if self.is_english(end_match[0].strip()):

--- a/runorm/runorm.py
+++ b/runorm/runorm.py
@@ -44,7 +44,7 @@ class RUNorm:
         self.angl_model = T5ForConditionalGeneration.from_pretrained(self.paths["kirillizator"], cache_dir=self.workdir)
         self.tagger_model = BertForTokenClassification.from_pretrained(self.paths["tagger"], cache_dir=self.workdir)
         self.tagger_tokenizer = AutoTokenizer.from_pretrained(self.paths["tagger"], cache_dir=self.workdir)
-        self.tagger = pipeline("ner", model=self.tagger_model, tokenizer=self.tagger_tokenizer, aggregation_strategy="average")
+        self.tagger = pipeline("ner", model=self.tagger_model, tokenizer=self.tagger_tokenizer, aggregation_strategy="average", device=device)
         self.abbr_model.to(device)
         self.angl_model.to(device)
         self.abbr_model.eval()


### PR DESCRIPTION
Теперь работает с XPU (Intel ARC 770m) с правильным pyTorch, для которого нужно пробрасывать device=xpu. Плюс починил ворнинги питона:
```
/data/speech/venv/lib/python3.12/site-packages/runorm/runorm.py:24: SyntaxWarning: invalid escape sequence '\['
  self.re_normalization = re.compile(r"[^a-zA-Z0-9\sа-яА-ЯёЁ.,!?:;""''(){}\[\]«»„“”-]")
/data/speech/venv/lib/python3.12/site-packages/runorm/runorm.py:110: SyntaxWarning: invalid escape sequence '\d'
  if not re.search("[a-zA-Z\d]", token):
```